### PR TITLE
feat: support quoted string keys in HCL objects

### DIFF
--- a/src/main/kotlin/bot/stewart/hcl/HclParser.kt
+++ b/src/main/kotlin/bot/stewart/hcl/HclParser.kt
@@ -154,7 +154,7 @@ class HclParser {
             if (input[position] == '}') break
 
             if (skipLineIfCommented()) continue
-            val key = parseKey()
+            val key = if (input[position] == '"') parseString() else parseKey()
             skipWhitespace()
             expect('=')
             skipWhitespace()

--- a/src/test/kotlin/bot/stewart/hcl/HclParserTest.kt
+++ b/src/test/kotlin/bot/stewart/hcl/HclParserTest.kt
@@ -325,6 +325,20 @@ class HclParserTest {
     }
 
     @Test
+    fun `parse quoted key in object`() {
+        parser.parse(
+            """
+            params = {
+              "test.quoted.key" = "test.value"
+            }
+            """.trimIndent(),
+        ).let { result ->
+            val params = result["params"] as Map<*, *>
+            assertEquals("test.value", params["test.quoted.key"])
+        }
+    }
+
+    @Test
     fun `parse complex nested structure`() {
         val nestedStructure = this::class.java.getResourceAsStream("/nested_structure.tfvars")?.bufferedReader()?.readText()!!
         parser.parse(nestedStructure).let { result ->


### PR DESCRIPTION
- Extends `parseObject()` to accept quoted string literals as object keys, e.g. `{ "some.dotted.key" = "value" }`
- Matches the [HCL spec `objectelem` grammar](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#collection-values), which allows either an `Identifier` or an `Expression` as a key
- No changes to the top-level `parse()` loop — top-level tfvars keys remain bare identifiers